### PR TITLE
add basic details page. target_url will need to be configurable in the future

### DIFF
--- a/lib/form-builder.js
+++ b/lib/form-builder.js
@@ -7,6 +7,7 @@ module.exports = function(commits) {
   return {
     state: state,
     context: 'Commit Message Validator',
-    description: description
+    description: description,
+    target_url: 'http://10.9.138.177:7000'
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 var Hapi = require('hapi'),
-    postHandler = require('../lib/post-handler');
+    postHandler = require('../lib/post-handler'),
+    fs = require('fs');
 
 
 var server = new Hapi.Server();
@@ -14,8 +15,9 @@ server.route({
   method: 'GET',
   path: '/',
   handler: function(request, reply) {
-    console.log('HEY IT WORKED!');
-    reply("WebHook");
+    fs.readFile('./pages/index.html', function(err, html) {
+      reply(html + "");
+    });
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "fs": "0.0.1-security",
     "hapi": "^15.0.3",
     "request": "^2.74.0",
     "underscore": "^1.8.3"

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Commit Message Validator</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    .sub-header {
+      margin-top: .5em;
+      margin-bottom: .5em;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-offset-3 col-md-6 text-center">
+        <h1>Commit Message Validator</h1>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-offset-1 col-md-10">
+        <div class="well col-md-3">
+          <h3 class="sub-header text-center">Overview</h3>
+        </div>
+        <div class="col-md-8 text-left">
+          <ul>
+            <li>This webhook is designed to validate that the title of your Pull Request (which will eventually become the merged commit message) is properly formatted</li>
+            <li>Your pull request should match the following regular expression:<code>/[a-zA-Z]+-\d+:.*/</code></li>
+            <li>Or look something like this: <b>ABC-123: this is a commit message</b></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Created a landing page so that when the PR status is reported people can get some more detail on what is going on here.

Right now just links to 10.9.138.177:7000 where the webhook is currently being hosted. This will need to be configurable in the future.
